### PR TITLE
Add generic classifier support for pants.

### DIFF
--- a/src/python/twitter/pants/targets/jar_dependency.py
+++ b/src/python/twitter/pants/targets/jar_dependency.py
@@ -37,9 +37,12 @@ class JarDependency(object):
 
   If the dependency has API docs available online, these can be noted with apidocs and generated
   javadocs with {@link}s to the jar's classes will be properly hyperlinked.
+
+  If you want to include a classifier variant of a jar, use the classifiers param. This takes a list of
+  classifiers. Include 'default' in the list to also pull in the classifier-less variant of the jar.
   """
 
-  def __init__(self, org, name, rev = None, force = False, ext = None, url = None, apidocs = None, test_jar = False):
+  def __init__(self, org, name, rev = None, force = False, ext = None, url = None, apidocs = None, classifiers = []):
     self.org = org
     self.name = name
     self.rev = rev
@@ -50,7 +53,7 @@ class JarDependency(object):
     self.url = url
     self.apidocs = apidocs
     self.id = None
-    self.test_jar = test_jar
+    self.classifiers = classifiers if type(classifiers) == list else [ classifiers ]
     self._configurations = [ 'default' ]
 
     # Support legacy method names
@@ -121,5 +124,6 @@ class JarDependency(object):
       transitive = self.transitive,
       ext = self.ext,
       url = self.url,
+      classifiers = self.classifiers,
       configurations = ';'.join(self._configurations),
     )

--- a/src/python/twitter/pants/tasks/ivy_resolve.py
+++ b/src/python/twitter/pants/tasks/ivy_resolve.py
@@ -250,7 +250,7 @@ class IvyResolve(NailgunTask):
       transitive = jar.transitive,
       ext = jar.ext,
       url = jar.url,
-      test_jar = jar.test_jar,
+      classifiers = jar.classifiers,
       configurations = ';'.join(jar._configurations),
     )
     override = self._overrides.get((jar.org, jar.name))

--- a/src/python/twitter/pants/tasks/ivy_resolve/ivy.mk
+++ b/src/python/twitter/pants/tasks/ivy_resolve/ivy.mk
@@ -69,7 +69,7 @@ limitations under the License.
                 transitive="false"
       % endif
     >
-      % if dependency.ext or dependency.url:
+      % if dependency.ext or dependency.url or "default" in dependency.classifiers:
       <artifact name="${dependency.module}"
         % if dependency.ext:
         ext="${dependency.ext}"
@@ -79,10 +79,13 @@ limitations under the License.
         % endif
       />
       % endif
-			% if dependency.test_jar: 
-			<artifact name="${dependency.module}" type="test-jar" ext="jar" m:classifier="tests"/>
-			<artifact name="${dependency.module}" type="jar" ext="jar" />
-			% endif
+      % if dependency.classifiers:
+        % for classifier in dependency.classifiers:
+          % if classifier != "default":
+            <artifact name="${dependency.module}" type="${classifier}" m:classifier="${classifier}" ext="jar" />
+          % endif
+        % endfor
+      % endif
       % if dependency.excludes:
         % for exclude in dependency.excludes:
           % if exclude.name:


### PR DESCRIPTION
Maven uses classifiers to label artifacts. Examples include "tests"
but it supports arbitrary text for a classifier (e.g. mrunit has
classifiers of either hadoop1 or hadoop2). Note that this is
different from ivy's configurations -- only some maven classifiers
are converted automatically to configurations.

This patch replaces the specific test-jar support in favor of generic
support for multiple classifiers.

Not super-happy with usage of 'default' -- would love a better sol'n.
