### PR TITLE
Artifact support for jar_dependencies.

### DIFF
--- a/src/python/twitter/pants/targets/jar_dependency.py
+++ b/src/python/twitter/pants/targets/jar_dependency.py
@@ -38,28 +38,32 @@ class JarDependency(object):
   If the dependency has API docs available online, these can be noted with apidocs and generated
   javadocs with {@link}s to the jar's classes will be properly hyperlinked.
 
-  If you want to include a classifier variant of a jar, use the classifiers param. This takes a list of
-  classifiers. Include 'default' in the list to also pull in the classifier-less variant of the jar.
+  If you want to include a classifier variant of a jar, use the classifier param. If you want to include
+  multiple artifacts with differing classifiers, use with_artifact
   """
 
-  def __init__(self, org, name, rev = None, force = False, ext = None, url = None, apidocs = None, classifiers = []):
+  def __init__(self, org, name, rev = None, force = False, ext = None, url = None, apidocs = None, type_ = None, classifier = None):
     self.org = org
     self.name = name
     self.rev = rev
     self.force = force
     self.excludes = []
     self.transitive = True
-    self.ext = ext
-    self.url = url
     self.apidocs = apidocs
+    self.artifacts = []
+    if ext or url or type_ or classifier:
+      self.with_artifact(name=name, ext=ext, url=url, type_=type_, classifier=classifier)
     self.id = None
-    self.classifiers = classifiers if type(classifiers) == list else [ classifiers ]
     self._configurations = [ 'default' ]
 
     # Support legacy method names
     # TODO(John Sirois): introduce a deprecation cycle for these and then kill
     self.withSources = self.with_sources
     self.withDocs = self.with_sources
+
+    # Legacy variables needed by ivy jar publish
+    self.ext = ext
+    self.url = url
 
   def exclude(self, org, name = None):
     """Adds a transitive dependency of this jar to the exclude list."""
@@ -80,6 +84,10 @@ class JarDependency(object):
 
   def with_docs(self):
     self._configurations.append('docs')
+    return self
+
+  def with_artifact(self, name = None, ext = None, url = None, type_ = None, classifier = None, configuration = None):
+    self.artifacts.append(Artifact(name, ext, url, type_, classifier, configuration))
     return self
 
   # TODO: This is necessary duck-typing because in some places JarDependency is treated like
@@ -122,8 +130,21 @@ class JarDependency(object):
       force = self.force,
       excludes = self.excludes,
       transitive = self.transitive,
-      ext = self.ext,
-      url = self.url,
-      classifiers = self.classifiers,
+      artifacts = self.artifacts,
       configurations = ';'.join(self._configurations),
     )
+
+class Artifact(object):
+  """
+  Specification for an Ivy Artifact for this jar dependency.
+
+  http://ant.apache.org/ivy/history/latest-milestone/ivyfile/artifact.html
+  """
+
+  def __init__(self, name = None, ext = None, url = None, type_ = None, classifier = None, conf = None):
+    self.name = name
+    self.ext = ext
+    self.url = url
+    self.type_ = type_
+    self.classifier = classifier
+    self.conf = conf

--- a/src/python/twitter/pants/tasks/cache_manager.py
+++ b/src/python/twitter/pants/tasks/cache_manager.py
@@ -233,7 +233,6 @@ class CacheManager(object):
     'force',
     'excludes',
     'transitive',
-    'ext',
-    'url',
-    '_configurations'
+    '_configurations',
+    'artifacts'
     )

--- a/src/python/twitter/pants/tasks/ivy_resolve.py
+++ b/src/python/twitter/pants/tasks/ivy_resolve.py
@@ -248,9 +248,7 @@ class IvyResolve(NailgunTask):
       force = jar.force,
       excludes = [self._generate_exclude_template(exclude) for exclude in jar.excludes],
       transitive = jar.transitive,
-      ext = jar.ext,
-      url = jar.url,
-      classifiers = jar.classifiers,
+      artifacts = jar.artifacts,
       configurations = ';'.join(jar._configurations),
     )
     override = self._overrides.get((jar.org, jar.name))

--- a/src/python/twitter/pants/tasks/ivy_resolve/ivy.mk
+++ b/src/python/twitter/pants/tasks/ivy_resolve/ivy.mk
@@ -69,21 +69,28 @@ limitations under the License.
                 transitive="false"
       % endif
     >
-      % if dependency.ext or dependency.url or "default" in dependency.classifiers:
-      <artifact name="${dependency.module}"
-        % if dependency.ext:
-        ext="${dependency.ext}"
-        % endif
-        % if dependency.url:
-        url="${dependency.url}"
-        % endif
-      />
-      % endif
-      % if dependency.classifiers:
-        % for classifier in dependency.classifiers:
-          % if classifier != "default":
-            <artifact name="${dependency.module}" type="${classifier}" m:classifier="${classifier}" ext="jar" />
-          % endif
+      % if dependency.artifacts:
+        % for artifact in dependency.artifacts:
+            <artifact
+              % if artifact.name:
+              name="${artifact.name}"
+              % endif
+              % if artifact.ext:
+              ext="${artifact.ext}"
+              % endif
+              % if artifact.url:
+              url="${artifact.url}"
+              % endif
+              % if artifact.type_:
+              type="${artifact.type_}"
+              % endif
+              % if artifact.classifier:
+              m:classifier="${artifact.classifier}"
+              % endif
+              % if artifact.conf:
+              conf="${artifact.conf}"
+              % endif
+            />
         % endfor
       % endif
       % if dependency.excludes:


### PR DESCRIPTION
Proper support for ivy artifacts via jar_dependency#with_artifact.
Moves the logic to generate an artifact if theres an ext/url (and
now type or classifier) into the jar_dependency and out of the
mako template. The ext/url members of jar_dependency are kept around
for backwards compatibility both of **init** and publishing jars.
