### PR TITLE
Add dependency checking to scala_compiler.

### DIFF
--- a/src/python/twitter/pants/BUILD
+++ b/src/python/twitter/pants/BUILD
@@ -46,6 +46,7 @@ python_library(
     pants("src/python/twitter/common/dirutil"),
     pants("src/python/twitter/common/lang"),
     pants("src/python/twitter/common/python"),
+    pants("src/python/twitter/common/java"),
     pants(":pants-deps"),
   ],
   sources = PANTS_SOURCES,

--- a/src/python/twitter/pants/ant/templates/ivy.mk
+++ b/src/python/twitter/pants/ant/templates/ivy.mk
@@ -60,15 +60,29 @@ limitations under the License.
                 transitive="false"
       % endif
     >
-      % if dependency.ext or dependency.url:
-      <artifact name="${dependency.module}"
-        % if dependency.ext:
-        ext="${dependency.ext}"
-        % endif
-        % if dependency.url:
-        url="${dependency.url}"
-        % endif
-      />
+      % if dependency.artifacts:
+        % for artifact in dependency.artifacts:
+            <artifact
+              % if artifact.name:
+              name="${artifact.name}"
+              % endif
+              % if artifact.ext:
+              ext="${artifact.ext}"
+              % endif
+              % if artifact.url:
+              url="${artifact.url}"
+              % endif
+              % if artifact.type_:
+              type="${artifact.type_}"
+              % endif
+              % if artifact.classifier:
+              m:classifier="${artifact.classifier}"
+              % endif
+              % if artifact.conf:
+              conf="${artifact.conf}"
+              % endif
+            />
+        % endfor
       % endif
       % if dependency.excludes:
         % for exclude in dependency.excludes:

--- a/src/python/twitter/pants/tasks/jvm_compiler_dependencies.py
+++ b/src/python/twitter/pants/tasks/jvm_compiler_dependencies.py
@@ -109,3 +109,41 @@ class Dependencies(object):
         relsrc = os.path.relpath(sourcefile, target.target_base)
         classes_by_target_by_source[target][relsrc] = classfiles
     return classes_by_target_by_source
+
+  def getClassToTargetMap(self, targets):
+    """
+      Gets a map from class to a list of the targets that provides the class.
+      If the class is part of more than one target, then the value in
+      the map will be a list of targets.
+
+      (Note that the same class provided by multiple targets should be
+      an error, but this isn't the right place to signal that; instead, here,
+      we just want a consistent mapping describing the class/target relationship.)
+
+      Params:
+         targets - a list of targets that should be included in this map.
+      Returns: a map from class files to lists of targets which provide those
+         targets.
+    """
+    result = dict()
+    sources = set()
+    target_by_source = dict()
+    for target in targets:
+      for source in target.sources:
+        src = os.path.normpath(os.path.join(target.target_base, source))
+        target_by_source[src] = target
+        sources.add(src)
+    for sourcefile, classfiles in self.classes_by_source.items():
+      src = os.path.normpath(os.path.join(target.target_base, source))
+      target = target_by_source[src]
+      for clazz in classfiles:
+        if clazz in result:
+          targets = result[clazz]
+          targets.append(target)
+        else:
+          result[clazz] = [ target ]
+    return result
+
+
+
+

--- a/src/python/twitter/pants/tasks/scala_compile.py
+++ b/src/python/twitter/pants/tasks/scala_compile.py
@@ -81,7 +81,8 @@ class ScalaCompile(NailgunTask):
 
     # We use the scala_compile_color flag if it is explicitly set on the command line.
     self._color = \
-      context.options.scala_compile_color or context.config.getbool('scala-compile', 'color', default=True)
+      context.options.scala_compile_color if context.options.scala_compile_color is not None else \
+      context.config.getbool('scala-compile', 'color', default=True)
 
     self._compile_profile = context.config.get('scala-compile', 'compile-profile')  # The target scala version.
     self._zinc_profile = context.config.get('scala-compile', 'zinc-profile')


### PR DESCRIPTION
Adds an optional analysis pass post-compilation for scala
targets that uses real class dependencies to generate a list
of the scala targets that any compilation target actually depends
on, and then compares that to the declared list of dependencies
to detect any spurious dependencies that are accidentally permitted
by the chunked compiler.
