### PR TITLE
ext/url are no longer used.

### DIFF
--- a/src/python/twitter/pants/tasks/jar_publish.py
+++ b/src/python/twitter/pants/tasks/jar_publish.py
@@ -237,7 +237,7 @@ class IvyWriter(DependencyWriter):
       publications=set(confs) if confs else set(),
     ))
 
-  def _jardep(self, jar, transitive=True, ext=None, url=None, configurations='default'):
+  def _jardep(self, jar, transitive=True, configurations='default'):
     return TemplateData(
       org=jar.org,
       module=jar.name,
@@ -245,8 +245,7 @@ class IvyWriter(DependencyWriter):
       force=jar.force,
       excludes=[self.create_exclude(exclude) for exclude in jar.excludes],
       transitive=transitive,
-      ext=ext,
-      url=url,
+      artifacts=jar.artifacts,
       configurations=configurations,
     )
 


### PR DESCRIPTION
artifacts are used instead. Fixes ./pants publish.
