### PR TITLE
Update dependency checking for instransitive deps.

### DIFF
--- a/src/python/twitter/pants/tasks/scala_compile.py
+++ b/src/python/twitter/pants/tasks/scala_compile.py
@@ -78,10 +78,11 @@ class ScalaCompile(NailgunTask):
                             default=False,
                             help="[%default] Check for undeclared dependencies in scala code")
 
-    option_group.add_option(mkflag("intransitive-deps"),
+    # This flag should eventually be removed once code is in compliance.
+    option_group.add_option(mkflag("check-missing-intransitive-deps"),
                             type="choice",
                             action='store',
-                            dest='scala_intransitive_deps',
+                            dest='scala_check_intransitive_deps',
                             choices=['none', 'warn', 'error'],
                             default='none',
                             help="[%default] Enable errors for undeclared deps that don't cause compilation" \
@@ -98,7 +99,7 @@ class ScalaCompile(NailgunTask):
       context.config.getint('scala-compile', 'partition_size_hint')
 
     self.check_missing_deps = context.options.scala_check_missing_deps
-    self.intransitive = context.options.scala_intransitive_deps
+    self.check_intransitive_deps = context.options.scala_check_intransitive_deps
     if self.check_missing_deps:
       JvmDependencyCache.init_product_requirements(self)
 
@@ -223,10 +224,10 @@ class ScalaCompile(NailgunTask):
           #  for jd in jar_deps:
           #    print ("Error: target %s needs to depend on jar_dependency %s.%s" %
           #          (target.address, jd.org, jd.name))
-          if self.intransitive != "none":            
+          if self.check_intransitive_deps != "none":
             if len(immediate_missing_deps) > 0:
               genmap = self.context.products.get('missing_deps')
-              if self.intransitive == "error":
+              if self.check_intransitive_deps == "error":
                 found_missing_deps = True
                 genmap.add(target, self.context._buildroot,
                            [x.derived_from.address.reference() for x in immediate_missing_deps])


### PR DESCRIPTION
Before this change, the dependency checking code only generated errors
in cases where, without chunking, compilation would fail.

For example, if the following targets and deps were declared:

```
scala_library(name="A", ..., deps=[pants("B")])
scala_library(name="B", ..., deps=[pants("C")])
scala_library(name="C", ...)
```

If the source files in target A actually referenced members of C,
the compilation would not fail, and no dependency checking error message
would be generated. But if A explicitly references members of C, it
should declare that dependency.

This change adds a dependency checking flag, "intransitive-deps", which
can be set to either "none", "warn", or "error".

If the flag is set to "none" (the default), then the dependency checker will
not generate errors for intransitive dependencies.

If the flag is set to "warn", then the dependency checker will
print error messages for intransitive deps, but will cause the build
to fail, and will not populate the build products with the errors.

If the flag is set to "error", then it will print out error messages
for intransitive deps, populate the build products with information
about the deps, and will cause the build to fail with an error.
