### PR TITLE
Fix --no-compile-scalac-color flag

### DIFF
--- a/src/python/twitter/pants/tasks/scala_compile.py
+++ b/src/python/twitter/pants/tasks/scala_compile.py
@@ -63,7 +63,8 @@ class ScalaCompile(NailgunTask):
     NailgunTask.__init__(self, context, workdir=context.config.get('scala-compile', 'nailgun_dir'))
 
     # Set up the zinc utils.
-    color = context.options.scala_compile_color or \
+    # Command line switch overrides color setting set in pants.ini
+    color = context.options.scala_compile_color if context.options.scala_compile_color is not None else \
             context.config.getbool('scala-compile', 'color', default=True)
 
     self._zinc_utils = ZincUtils(context=context, java_runner=self.runjava, color=color)


### PR DESCRIPTION
Logic was previously ignoring the --no-compile-scalac-color flag. Since it was
setting that value to False, the other half of the or-condition was being
evaluated and the default True value was used. This ensures that the
--no-compile-scalac-color flag is heeded and overrides whatever is set in
pants.ini.
