### PR TITLE
Don't chdir when shelling out to thrift

### DIFF
--- a/src/python/twitter/pants/python/thrift_builder.py
+++ b/src/python/twitter/pants/python/thrift_builder.py
@@ -80,18 +80,13 @@ class PythonThriftBuilder(object):
       'py:new_style',
       '-recurse',
       '-o',
-      self.codegen_root
+      os.path.join(self.chroot.path(), self.codegen_root)
     ]
     for base in bases:
       args.extend(('-I', base))
     args.append(thrift_abs_path)
 
-    cwd = os.getcwd()
-    os.chdir(self.chroot.path())
-    try:
-      po = subprocess.Popen(args)
-    finally:
-      os.chdir(cwd)
+    po = subprocess.Popen(args)
     rv = po.wait()
     if rv != 0:
       comm = po.communicate()


### PR DESCRIPTION
Instead, turn the output (-o) parameter to thrift
into an absolute path.  This fixes a bug where
thrift files that include other thrift files
relative to a base passed in via -I are unable
to find the included file, since thrift is
being run with a working directory of codegen_root
rather than the process's initial cwd.
