### PR TITLE
Report stats to server.

### DIFF
--- a/src/python/twitter/pants/goal/run_tracker.py
+++ b/src/python/twitter/pants/goal/run_tracker.py
@@ -147,8 +147,10 @@ class RunTracker(object):
         http_conn.request('POST', url.path, urllib.urlencode(params), headers)
         resp = http_conn.getresponse()
         if resp.status != 200:
+          # Report aleady closed, so just print error
           print "WARNING: Failed to upload stats. HTTP error code: %d" % resp.status
-      except socket.error, (value, message):
+      except socket.error as (value, message):
+          # Report aleady closed, so just print error
           print "WARNING: Failed to upload stats. Socket error: %s" % message
 
   def end(self):


### PR DESCRIPTION
Specify stats_upload_url to pants.ini to receive a
POST form with 'cumulative_timings', 'self_timings',
'artifact_cache_timings', and 'run_info' params, each of
which have a JSON body.
