### PR TITLE
inhibit ng lsof port->name conversion

### DIFF
--- a/src/python/twitter/pants/tasks/nailgun_task.py
+++ b/src/python/twitter/pants/tasks/nailgun_task.py
@@ -359,7 +359,7 @@ class NailgunProcessManager(object):
     pid = pids[0]
 
     # Expected output of the lsof cmd: pPID\nn[::127.0.0.1]:PORT
-    lines = NailgunProcessManager._run_cmd('lsof -a -p %s -i TCP -s TCP:LISTEN -Fn' % pid)
+    lines = NailgunProcessManager._run_cmd('lsof -a -p %s -i TCP -s TCP:LISTEN -P -Fn' % pid)
     if lines is None or len(lines) != 2 or lines[0] != 'p%s' % pid:
       return None
     port = lines[1][lines[1].rfind(':') + 1:].strip()


### PR DESCRIPTION
without -P (e.g. port 8080):
p[PID]
n*:webcache

with -P:
p[PID]
n*:8080
