### PR TITLE
Add resource dependencies to jars

### DIFF
--- a/src/python/twitter/pants/targets/resources.py
+++ b/src/python/twitter/pants/targets/resources.py
@@ -18,7 +18,7 @@ import os
 
 from collections import Sequence
 
-from twitter.pants import is_concrete
+from twitter.pants import get_buildroot, is_concrete
 from twitter.pants.base import ParseContext, Target
 from twitter.pants.targets.with_sources import TargetWithSources
 
@@ -26,6 +26,18 @@ from twitter.pants.targets.with_sources import TargetWithSources
 class Resources(TargetWithSources):
   """Describes a set of resource files to be embedded in a library or binary."""
 
+  def __init__(self, name, sources=None, exclusives=None, prefix=None):
+    TargetWithSources.__init__(self, name, sources=sources, exclusives=exclusives)
+    self.prefix = prefix
+
+  def archive_paths(self):
+    # if no path, use the build root. Otherwise it would be
+    # very easy to get conflicting files.
+    prefix = self.prefix
+    if prefix is None:
+      prefix = get_buildroot()
+    for abspath in self.expand_files(recursive=False):
+      yield (abspath, os.path.relpath(abspath, prefix))
 
 class WithLegacyResources(TargetWithSources):
   """Collects resources whether they are specified using globs against an assumed parallel

--- a/src/python/twitter/pants/tasks/binary_create.py
+++ b/src/python/twitter/pants/tasks/binary_create.py
@@ -86,6 +86,7 @@ class BinaryCreate(JvmBinaryTask):
       if self.deployjar:
         for basedir, externaljar in self.list_jar_dependencies(binary):
           self.dump(os.path.join(basedir, externaljar), jar)
+      self.dump_resources(binary, jar)
 
       manifest = Manifest()
       manifest.addentry(Manifest.MANIFEST_VERSION, '1.0')
@@ -98,6 +99,12 @@ class BinaryCreate(JvmBinaryTask):
       jar.writestr(Manifest.PATH, manifest.contents())
 
       jarmap.add(binary, self.outdir, [binary_jarname])
+
+  def dump_resources(self, binary, jarfile):
+    for resources in binary.resources:
+      self.context.log.debug('  writing resources from: %s' % repr(resources))
+      for path, arcpath in resources.archive_paths():
+        jarfile.write(path, arcpath)
 
   def dump(self, jarpath, jarfile):
     self.context.log.debug('  dumping %s' % jarpath)


### PR DESCRIPTION
We want to be able to include resources in jar files.  The resource functionality exists but is ignored during the jvm binary command. This pull request adds that functionality along with the ability to specify a "prefix" for a set of resources. The prefix, defaulting to the pants build root, is removed from the resource paths when added them to the jar.
