### PR TITLE
Add .war extension to _map_jar

### DIFF
--- a/src/python/twitter/pants/tasks/ivy_resolve.py
+++ b/src/python/twitter/pants/tasks/ivy_resolve.py
@@ -477,7 +477,7 @@ class IvyResolve(NailgunTask):
 
   def _map_jar(self, path):
     """Subclasses can override to determine whether a given path represents a mappable artifact."""
-    return path.endswith('.jar')
+    return path.endswith('.jar') or path.endswith('.war')
 
   def _exec_ivy(self, target_workdir, targets, args):
     ivyxml = os.path.join(target_workdir, 'ivy.xml')


### PR DESCRIPTION
- this allows 3rdparty .war dependencies to be bundled into
  an app bundle.  You can use this to serve 3rdparty
  web applications from a jetty container server, and
  have this managed via ivy.

There is no branch for the current non-beta, so not sure which pull request to send this branch to.
