### PR TITLE
Add PANTS_CONFIG_OVERRIDE to allow a second config file

### DIFF
--- a/src/python/twitter/pants/base/config.py
+++ b/src/python/twitter/pants/base/config.py
@@ -65,10 +65,20 @@ class Config(object):
     return ConfigParser.SafeConfigParser(standard_defaults)
 
   def __init__(self, configparser, configpath):
+    # Base Config
     self.configparser = configparser
     with open(configpath) as ini:
       self.configparser.readfp(ini, filename=configpath)
     self.file = configpath
+
+    # Overrides
+    self.overrides_path = os.environ.get('PANTS_CONFIG_OVERRIDE')
+    self.overrides_parser = None
+    if self.overrides_path is not None:
+      self.overrides_path = os.path.join(get_buildroot(), self.overrides_path)
+      self.overrides_parser = Config.create_parser()
+      with open(self.overrides_path) as o_ini:
+        self.overrides_parser.readfp(o_ini, filename=self.overrides_path)
 
   def getbool(self, section, option, default=None):
     """Equivalent to calling get with expected type string"""
@@ -106,10 +116,22 @@ class Config(object):
     """
     return self._getinstance(section, option, type, default=default)
 
+  def _has_option(self, section, option):
+    if self.overrides_parser and self.overrides_parser.has_option(section, option):
+      return True
+    elif self.configparser.has_option(section, option):
+      return True
+    return False
+
+  def _get_value(self, section, option):
+    if self.overrides_parser and self.overrides_parser.has_option(section, option):
+      return self.overrides_parser.get(section, option)
+    return self.configparser.get(section, option)
+
   def _getinstance(self, section, option, type, default=None):
-    if not self.configparser.has_option(section, option):
+    if not self._has_option(section, option):
       return default
-    raw_value = self.configparser.get(section, option)
+    raw_value = self._get_value(section, option)
     if issubclass(type, str):
       return raw_value
 


### PR DESCRIPTION
- PANTS_CONFIG_OVERRIDE specifies a buildroot-relative config file path
- An env variable was chosen because pants.ini is loaded before argument
  parsing
- That file is loaded along with pants.ini
- If a value is in the override file it is chosen instead of pants.ini
- There's no cross-referencing between the files, so each file must be
  internally consistent
